### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/HoneyBerries/Modcord/security/code-scanning/2](https://github.com/HoneyBerries/Modcord/security/code-scanning/2)

The problem is that the workflow does not include a `permissions` block, so the job will use the default repository permissions, which may not comply with the principle of least privilege. To fix, you should add a minimal permissions block:  
- Add `permissions: contents: read` at either the workflow root or at the job level, before your jobs are listed or inside the test job definition.  
- Since the workflow does not appear to require any write operations to the repository, the minimal set is `contents: read`.  
- The best location is immediately after the workflow `name` line, to cover all jobs in the workflow.

**Steps**:
- Edit file: `.github/workflows/tests.yaml`
- Between line 1 (`name: Run Tests`) and line 2, insert:
  ```yaml
  permissions:
    contents: read
  ```
- No imports or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
