### PR TITLE
Bump dependencies: openai-java, jackson-databind, jline

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,10 +7,10 @@ org-liquibase-gradle = { id = "org.liquibase.gradle", version = "3.1.0" }
 
 [libraries]
 
-openai-java = "com.openai:openai-java:4.30.0"
+openai-java = "com.openai:openai-java:4.32.0"
 
 gson = "com.google.code.gson:gson:2.13.2"
-jackson-databind = "tools.jackson.core:jackson-databind:3.1.1"
+jackson-databind = "tools.jackson.core:jackson-databind:3.1.2"
 
 jda = "net.dv8tion:JDA:6.4.1"
 
@@ -37,6 +37,6 @@ liquibase-core = "org.liquibase:liquibase-core:5.0.2"
 
 picocli = "info.picocli:picocli:4.7.7"
 
-jline = "org.jline:jline:4.0.10"
+jline = "org.jline:jline:4.0.12"
 
 apache-commons-lang3 = "org.apache.commons:commons-lang3:3.20.0"


### PR DESCRIPTION
## Summary

Dependency updates identified via `./gradlew refreshVersions` with security advisory research.

### Updated (stable releases only)

| Dependency | From | To | Type |
|---|---|---|---|
| `com.openai:openai-java` | 4.30.0 | 4.32.0 | Minor |
| `tools.jackson.core:jackson-databind` | 3.1.1 | 3.1.2 | Patch |
| `org.jline:jline` | 4.0.10 | 4.0.12 | Patch |

### Skipped (pre-release)

| Dependency | Available | Reason |
|---|---|---|
| `slf4j-api` | 2.1.0-alpha1 | Alpha — not stable |
| `junit-platform-launcher` | 6.1.0-M1 | Milestone — not stable |
| Gradle wrapper | 9.5.0-rc-3 | Release candidate — not stable |

## Security Audit

| Dependency | CVE Status |
|---|---|
| `postgresql` 42.7.10 | ✅ Safe — CVE-2025-49146 (MITM via channel binding) was fixed in 42.7.7; we're above that |
| `jackson-databind` 3.1.1 | ✅ Safe — CVE-2025-52999 (DoS via deeply nested JSON) was fixed in 3.1.0; updating to 3.1.2 |
| `liquibase-core` 5.0.2 | ✅ Safe — CVE-2025-59250 affects the MSSQL JDBC driver bundled only in Liquibase **Secure** (commercial), not community |
| `JDA` 6.4.1 | ✅ No security advisories found |
| `openai-java` 4.32.0 | ✅ No security advisories found |

### openai-java 4.32.0 breaking change note

`ResponseFunctionToolCallOutputItem.output` and `ResponseCustomToolCallOutput.output` now return `string | Array<...>` instead of `string` only. **Verified: neither type is referenced anywhere in this codebase**, so this has no impact.

## Test plan

- [ ] `./gradlew assemble` succeeds (requires Java 25)
- [ ] `./gradlew test` passes
- [ ] Bot starts and connects to Discord normally

https://claude.ai/code/session_01V2WwA1b9QC8X34Xj4JTXTM