### PR TITLE
Changes. etc

### DIFF
--- a/src/main/java/net/honeyberries/database/repository/AppealRepository.java
+++ b/src/main/java/net/honeyberries/database/repository/AppealRepository.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -135,7 +134,7 @@ public class AppealRepository {
      * @throws NullPointerException if {@code guildId} is {@code null}
      */
     @NotNull
-    public List<AppealData> getOpenAppeals(@NotNull GuildID guildId) {
+    public List<AppealData> getOpenAppealsForGuild(@NotNull GuildID guildId) {
         Objects.requireNonNull(guildId, "guildId must not be null");
         String sql = """
             SELECT ma.appeal_id, ma.guild_id, ma.user_id, ma.action_id, ma.reason, ma.submitted_at,
@@ -171,6 +170,8 @@ public class AppealRepository {
             return List.of();
         }
     }
+
+
 
     /**
      * Maps a result set row (with joined action columns) into an {@code AppealData} with embedded {@code ActionData}.
@@ -208,6 +209,7 @@ public class AppealRepository {
         );
     }
 
+
     /**
      * Retrieves the UUIDs of all open appeals for a user in a guild.
      * Used to filter out already-appealed actions from the appeal selection menu.
@@ -222,7 +224,7 @@ public class AppealRepository {
         Objects.requireNonNull(userId, "userId must not be null");
         String sql = """
             SELECT action_id FROM moderation_appeals
-            WHERE guild_id = ? AND user_id = ? AND is_open = TRUE AND action_id IS NOT NULL
+            WHERE guild_id = ? AND user_id = ? AND is_open = TRUE
         """;
 
         try {
@@ -248,9 +250,58 @@ public class AppealRepository {
         }
     }
 
+
+    /**
+     * Retrieves all open appeals for a specific user in a guild.
+     *
+     * @param guildId the guild to query, must not be {@code null}
+     * @param userId  the user whose appeals to query, must not be {@code null}
+     * @return list of open appeal records for the user, never {@code null}
+     */
+    @NotNull
+    public List<AppealData> getOpenAppealsForUserInGuild(@NotNull GuildID guildId, @NotNull UserID userId) {
+        Objects.requireNonNull(guildId, "guildId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
+        String sql = """
+            SELECT ma.appeal_id, ma.guild_id, ma.user_id, ma.action_id, ma.reason, ma.submitted_at,
+                   gma.moderator_id, gma.action, gma.reason AS action_reason,
+                   gma.timeout_duration, gma.ban_duration, gma.created_at
+            FROM moderation_appeals ma
+            JOIN guild_moderation_actions gma ON ma.action_id = gma.action_id
+            WHERE ma.guild_id = ?
+              AND ma.user_id = ?
+              AND ma.is_open = TRUE
+              AND NOT EXISTS (
+                    SELECT 1 FROM guild_moderation_action_reversals r
+                    WHERE r.action_id = ma.action_id
+                  )
+            ORDER BY ma.submitted_at
+        """;
+
+        try {
+            return database.query(conn -> {
+                List<AppealData> results = new ArrayList<>();
+                try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                    ps.setLong(1, guildId.value());
+                    ps.setLong(2, userId.value());
+                    try (ResultSet rs = ps.executeQuery()) {
+                        while (rs.next()) {
+                            results.add(mapAppealWithAction(rs));
+                        }
+                    }
+                }
+                return results;
+            });
+        } catch (Exception e) {
+            logger.error("Failed to fetch open appeals for user {} in guild {}", userId, guildId, e);
+            return List.of();
+        }
+    }
+
+
     /**
      * Retrieves the UUIDs of all open appeals for a user across all guilds.
-     * Used by the appeal system in DMs where the user may be banned from some guilds.
+     * Used in DM context to filter out already-appealed actions.
      *
      * @param userId the user whose appeals to fetch, must not be {@code null}
      * @return list of action_id UUIDs that have open appeals, never {@code null}
@@ -259,8 +310,8 @@ public class AppealRepository {
     public List<UUID> getAllOpenAppealActionIds(@NotNull UserID userId) {
         Objects.requireNonNull(userId, "userId must not be null");
         String sql = """
-            SELECT action_id FROM moderation_appeals
-            WHERE user_id = ? AND is_open = TRUE AND action_id IS NOT NULL
+            SELECT DISTINCT action_id FROM moderation_appeals
+            WHERE user_id = ? AND is_open = TRUE
         """;
 
         try {
@@ -280,8 +331,10 @@ public class AppealRepository {
                 return results;
             });
         } catch (Exception e) {
-            logger.error("Failed to fetch all open appeal action IDs for user {}", userId, e);
+            logger.error("Failed to fetch open appeal action IDs for user {}", userId, e);
             return List.of();
         }
     }
+
+
 }

--- a/src/main/java/net/honeyberries/discord/slashCommands/AppealCommands.java
+++ b/src/main/java/net/honeyberries/discord/slashCommands/AppealCommands.java
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import net.honeyberries.database.repository.AppealRepository;
 import net.honeyberries.datatypes.action.AppealData;
 import net.honeyberries.datatypes.discord.GuildID;
+import net.honeyberries.datatypes.discord.UserID;
 import net.honeyberries.ui.AppealEmbedUI;
 import net.honeyberries.util.AppealCommandHelper;
 import net.honeyberries.util.DiscordUtils;
@@ -65,9 +66,12 @@ public class AppealCommands extends ListenerAdapter {
                         new SubcommandData("list", "List open appeals (administrator only, guild only)")
                                 .addOption(OptionType.INTEGER, "limit",
                                         "Number of appeals to show (default 5)", false),
+                        new SubcommandData("user", "List open appeals for a user (administrator only, guild only)")
+                                .addOption(OptionType.USER, "user", "The user to check", true),
                         new SubcommandData("get", "Get details of a specific appeal (administrator only, guild only)")
                                 .addOption(OptionType.STRING, "appeal_id",
                                         "UUID of the appeal to view", true),
+
                         new SubcommandData("close", "Close/resolve an appeal (administrator only, guild only)")
                                 .addOption(OptionType.STRING, "appeal_id",
                                         "UUID of the appeal to close", true)
@@ -109,8 +113,17 @@ public class AppealCommands extends ListenerAdapter {
                     }
                     handleList(event, guild);
                 }
+                case "user"   -> {
+                    Guild guild = event.getGuild();
+                    if (guild == null) {
+                        reply(event, "User appeals can only be checked inside a server.");
+                        return;
+                    }
+                    handleUser(event, guild);
+                }
                 case "get"    -> {
                     Guild guild = event.getGuild();
+
                     if (guild == null) {
                         reply(event, "Get can only be used inside a server.");
                         return;
@@ -221,7 +234,7 @@ public class AppealCommands extends ListenerAdapter {
         }
 
         GuildID guildId = GuildID.fromGuild(guild);
-        List<AppealData> openAppeals = AppealRepository.getInstance().getOpenAppeals(guildId);
+        List<AppealData> openAppeals = AppealRepository.getInstance().getOpenAppealsForGuild(guildId);
 
         if (openAppeals.isEmpty()) {
             reply(event, "No open appeals for this server.");
@@ -237,7 +250,7 @@ public class AppealCommands extends ListenerAdapter {
         for (AppealData appeal : appealsToShow) {
             User appellant = event.getJDA().retrieveUserById(appeal.userId().value()).complete();
             if (appellant != null) {
-                event.getHook().sendMessage(AppealEmbedUI.buildAppealNotificationEmbed(appeal, appellant)).setEphemeral(true).queue();
+                event.getHook().sendMessage(AppealEmbedUI.buildAppealEmbedForAdmins(appeal, appellant)).setEphemeral(true).queue();
             }
         }
     }
@@ -273,7 +286,7 @@ public class AppealCommands extends ListenerAdapter {
         }
 
         GuildID guildId = GuildID.fromGuild(guild);
-        List<AppealData> openAppeals = AppealRepository.getInstance().getOpenAppeals(guildId);
+        List<AppealData> openAppeals = AppealRepository.getInstance().getOpenAppealsForGuild(guildId);
         AppealData appeal = openAppeals.stream()
                 .filter(a -> a.id().equals(appealId))
                 .findFirst()
@@ -286,7 +299,7 @@ public class AppealCommands extends ListenerAdapter {
 
         User appellant = event.getJDA().retrieveUserById(appeal.userId().value()).complete();
         if (appellant != null) {
-            event.reply(AppealEmbedUI.buildAppealNotificationEmbed(appeal, appellant)).setEphemeral(true).queue();
+            event.reply(AppealEmbedUI.buildAppealEmbedForAdmins(appeal, appellant)).setEphemeral(true).queue();
         } else {
             reply(event, "Could not retrieve appellant information.");
         }
@@ -337,11 +350,46 @@ public class AppealCommands extends ListenerAdapter {
 
 
     /**
+     * Handles the {@code /appeal user} subcommand.
+     * Displays all open appeals for a specific user in the guild as rich embeds. Administrator only.
+     *
+     * @param event the interaction event, must not be {@code null}
+     * @param guild the guild in which the command was issued, must not be {@code null}
+     */
+    private void handleUser(@NotNull SlashCommandInteractionEvent event, @NotNull Guild guild) {
+        Objects.requireNonNull(event, "event must not be null");
+        Objects.requireNonNull(guild, "guild must not be null");
+
+        if (!DiscordUtils.isAdmin(event.getMember())) {
+            reply(event, "Only administrators can view appeals.");
+            return;
+        }
+
+        User targetUser = Objects.requireNonNull(event.getOption("user", OptionMapping::getAsUser));
+        GuildID guildId = GuildID.fromGuild(guild);
+        UserID userId = UserID.fromUser(targetUser);
+
+        List<AppealData> userAppeals = AppealRepository.getInstance().getOpenAppealsForUserInGuild(guildId, userId);
+
+        if (userAppeals.isEmpty()) {
+            reply(event, "No open appeals for user " + targetUser.getAsTag() + " in this server.");
+            return;
+        }
+
+        event.reply("Open appeals for " + targetUser.getEffectiveName() + " (" + userAppeals.size() + "):").setEphemeral(true).queue();
+        for (AppealData appeal : userAppeals) {
+            event.getHook().sendMessage(AppealEmbedUI.buildAppealEmbedForAdmins(appeal, targetUser)).setEphemeral(true).queue();
+        }
+    }
+
+
+    /**
      * Sends an ephemeral reply to the interaction.
      *
      * @param event   the interaction event, must not be {@code null}
      * @param message the reply text, must not be {@code null}
      */
+
     private static void reply(@NotNull SlashCommandInteractionEvent event, @NotNull String message) {
         Objects.requireNonNull(event, "event must not be null");
         Objects.requireNonNull(message, "message must not be null");

--- a/src/main/java/net/honeyberries/ui/AppealEmbedUI.java
+++ b/src/main/java/net/honeyberries/ui/AppealEmbedUI.java
@@ -36,7 +36,7 @@ public class AppealEmbedUI {
      * @return a {@code MessageCreateData} with the embed and action buttons
      */
     @NotNull
-    public static MessageCreateData buildAppealNotificationEmbed(
+    public static MessageCreateData buildAppealEmbedForAdmins(
             @NotNull AppealData appeal,
             @NotNull User appellant) {
         Objects.requireNonNull(appeal, "appeal must not be null");
@@ -81,6 +81,59 @@ public class AppealEmbedUI {
         return new MessageCreateBuilder()
                 .setEmbeds(embed.build())
                 .addComponents(ActionRow.of(acceptBtn, rejectBtn))
+                .build();
+    }
+
+    /**
+     * Builds a rich appeal notification embed without buttons (for sending to the appellant via DM).
+     * Displays the appellant, original action details, and the appeal reason.
+     *
+     * @param appeal the appeal data with embedded action info, must not be {@code null}
+     * @param appellant the user who submitted the appeal, must not be {@code null}
+     * @return a {@code MessageCreateData} with the embed and no components
+     */
+    @NotNull
+    public static MessageCreateData buildAppealEmbedForAppellant(
+            @NotNull AppealData appeal,
+            @NotNull User appellant) {
+        Objects.requireNonNull(appeal, "appeal must not be null");
+        Objects.requireNonNull(appellant, "appellant must not be null");
+
+        ActionData action = appeal.actionData();
+        UserID appellantId = UserID.fromUser(appellant);
+
+        EmbedBuilder embed = new EmbedBuilder()
+                .setTitle(ActionHelper.actionEmoji(action.action()) + " Appeal — " + action.action().name())
+                .setColor(Color.CYAN)
+                .setTimestamp(appeal.submittedTimestamp())
+                .addField("Appellant", DiscordUtils.userMention(appellantId), true)
+                .addField("Moderator", DiscordUtils.userMention(action.moderatorId()), true)
+                .addField("Action Type", action.action().name(), true)
+                .addField("Original Reason", action.reason(), false)
+                .addField("Appeal Reason", appeal.reason(), false)
+                .setThumbnail(appellant.getEffectiveAvatarUrl())
+                .setFooter("Appeal ID: " + appeal.id());
+
+        if (action.action() == ActionType.TIMEOUT && action.timeoutDuration() > 0) {
+            Instant expiresAt = action.timestamp().plusSeconds(action.timeoutDuration());
+            embed.addField("Duration",
+                    formatDuration(action.timeoutDuration()) + " — expires " + TimeFormat.RELATIVE.format(expiresAt),
+                    false);
+        }
+
+        if (action.action() == ActionType.BAN && action.banDuration() > 0) {
+            if (action.banDuration() >= Integer.MAX_VALUE) {
+                embed.addField("Duration", "Permanent", false);
+            } else {
+                Instant expiresAt = action.timestamp().plusSeconds(action.banDuration());
+                embed.addField("Duration",
+                        formatDuration(action.banDuration()) + " — expires " + TimeFormat.RELATIVE.format(expiresAt),
+                        false);
+            }
+        }
+
+        return new MessageCreateBuilder()
+                .setEmbeds(embed.build())
                 .build();
     }
 

--- a/src/main/java/net/honeyberries/util/AppealCommandHelper.java
+++ b/src/main/java/net/honeyberries/util/AppealCommandHelper.java
@@ -1,13 +1,12 @@
 package net.honeyberries.util;
 
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.honeyberries.action.RollbackHandler;
 import net.honeyberries.database.repository.AppealRepository;
@@ -15,8 +14,10 @@ import net.honeyberries.database.repository.GuildModerationActionsRepository;
 import net.honeyberries.datatypes.action.ActionData;
 import net.honeyberries.datatypes.action.ActionType;
 import net.honeyberries.datatypes.action.AppealData;
+import net.honeyberries.datatypes.discord.ChannelID;
 import net.honeyberries.datatypes.discord.GuildID;
 import net.honeyberries.datatypes.discord.UserID;
+import net.honeyberries.datatypes.preferences.GuildPreferences;
 import net.honeyberries.preferences.PreferencesManager;
 import net.honeyberries.ui.AppealEmbedUI;
 import org.jetbrains.annotations.NotNull;
@@ -141,16 +142,19 @@ public class AppealCommandHelper {
         }
 
         // Load the full AppealData from DB (with embedded ActionData)
-        List<AppealData> openAppeals = appealRepository.getOpenAppeals(action.guildId());
+        List<AppealData> openAppeals = appealRepository.getOpenAppealsForGuild(action.guildId());
         AppealData appeal = openAppeals.stream()
                 .filter(a -> a.id().equals(appealId))
                 .findFirst()
                 .orElse(null);
 
-        // Notify moderators
+        // Notify moderators and the appealent.
         Guild guild = event.getJDA().getGuildById(action.guildId().value());
+
         if (guild != null && appeal != null) {
-            notifyModerators(event.getJDA(), guild, appeal, event.getUser());
+            notifyModerators(guild, appeal, event.getUser());
+            sendAppealConfirmationToAppellant(event.getUser(), appeal);
+
         } else if (guild == null) {
             logger.warn("Guild {} not found for appeal notification", action.guildId().value());
         } else {
@@ -164,30 +168,46 @@ public class AppealCommandHelper {
      * Sends a notification to moderators in the audit log channel with Accept/Reject buttons.
      */
     private void notifyModerators(
-            @NotNull JDA jda,
             @NotNull Guild guild,
             @NotNull AppealData appeal,
             @NotNull User appellant) {
         try {
-            var prefs = PreferencesManager.getInstance().getOrDefaultPreferences(new GuildID(guild.getIdLong()));
-            var auditLogChannel = guild.getTextChannelById(prefs.auditLogChannelId().value());
+            GuildPreferences prefs = PreferencesManager.getInstance().getOrDefaultPreferences(new GuildID(guild.getIdLong()));
 
-            if (auditLogChannel == null) {
-                // Fallback to hardcoded channel name if no preference is set
-                auditLogChannel = guild.getTextChannels().stream()
-                        .filter(channel -> channel.getName().equals("audit-log"))
-                        .findFirst()
-                        .orElse(null);
+            ChannelID auditChannel = prefs.auditLogChannelId();
+
+            if (auditChannel == null) {
+                logger.debug("Audit log channel not configured in guild {} — appeal will not be notified to moderators", guild.getId());
+                return;
             }
+
+            TextChannel auditLogChannel = guild.getTextChannelById(auditChannel.value());
+
 
             if (auditLogChannel == null) {
                 logger.debug("Audit log channel not found in guild {} — appeal will not be notified to moderators", guild.getId());
                 return;
             }
 
-            auditLogChannel.sendMessage(AppealEmbedUI.buildAppealNotificationEmbed(appeal, appellant)).queue();
+            auditLogChannel.sendMessage(AppealEmbedUI.buildAppealEmbedForAdmins(appeal, appellant)).queue();
         } catch (Exception e) {
             logger.error("Failed to notify moderators of appeal {} in guild {}", appeal.id(), guild.getId(), e);
+        }
+    }
+
+    /**
+     * Sends the appeal confirmation embed to the appellant via DM (without buttons).
+     */
+    private void sendAppealConfirmationToAppellant(
+            @NotNull User appellant,
+            @NotNull AppealData appeal) {
+        try {
+            appellant.openPrivateChannel()
+                    .flatMap(channel -> channel.sendMessage(AppealEmbedUI.buildAppealEmbedForAppellant(appeal, appellant)))
+                    .queue(success -> logger.info("Appeal confirmation sent to user {} for appeal {}", appellant.getId(), appeal.id()),
+                           error -> logger.warn("Failed to send appeal confirmation to user {} for appeal {}", appellant.getId(), appeal.id()));
+        } catch (Exception e) {
+            logger.error("Failed to send appeal confirmation to appellant {} for appeal {}", appellant.getId(), appeal.id(), e);
         }
     }
 
@@ -221,7 +241,7 @@ public class AppealCommandHelper {
         }
 
         // Load the guild from the event
-        var guild = event.getGuild();
+        Guild guild = event.getGuild();
         if (guild == null) {
             event.reply("Guild not found.").setEphemeral(true).queue();
             return;
@@ -230,7 +250,7 @@ public class AppealCommandHelper {
         GuildID guildId = new GuildID(guild.getIdLong());
 
         // Find the appeal in the open appeals list
-        List<AppealData> openAppeals = appealRepository.getOpenAppeals(guildId);
+        List<AppealData> openAppeals = appealRepository.getOpenAppealsForGuild(guildId);
         AppealData appeal = openAppeals.stream()
                 .filter(a -> a.id().equals(appealId))
                 .findFirst()
@@ -286,7 +306,7 @@ public class AppealCommandHelper {
             }
 
             // Update the embed: change to red with "Rejected" title
-            updateAppealEmbedRejected(event, appeal, moderatorName);
+            updateAppealEmbedRejected(event, appeal);
             event.getHook().sendMessage("Appeal rejected.").setEphemeral(true).queue();
         }
     }
@@ -322,8 +342,7 @@ public class AppealCommandHelper {
      */
     private void updateAppealEmbedRejected(
             @NotNull ButtonInteractionEvent event,
-            @NotNull AppealData appeal,
-            @NotNull String moderatorName) {
+            @NotNull AppealData appeal) {
         event.deferEdit().queue();
 
         EmbedBuilder embed = new EmbedBuilder()

--- a/src/main/resources/db/changelog/changelog-v19.sql
+++ b/src/main/resources/db/changelog/changelog-v19.sql
@@ -1,0 +1,3 @@
+--changeset pepmon:19
+ALTER TABLE guild_preferences ADD COLUMN allow_appeals BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE guild_preferences ADD COLUMN allow_reappeals BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/net/honeyberries/action/TestRollbackHandler.java
+++ b/src/test/java/net/honeyberries/action/TestRollbackHandler.java
@@ -1,0 +1,119 @@
+package net.honeyberries.action;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.honeyberries.config.AppConfig;
+import net.honeyberries.database.Database;
+import net.honeyberries.database.repository.GuildModerationActionsRepository;
+import net.honeyberries.datatypes.action.ActionData;
+import net.honeyberries.datatypes.action.ActionType;
+import net.honeyberries.datatypes.discord.GuildID;
+import net.honeyberries.datatypes.discord.UserID;
+import net.honeyberries.discord.JDAManager;
+import org.junit.jupiter.api.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@DisplayName("Rollback Handler Tests")
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestRollbackHandler {
+
+    private static final Database database = Database.getInstance();
+    private static final AppConfig appConfig = AppConfig.getInstance();
+
+    private static final long TEST_ACCOUNT_2_ID = 1180022370375835731L;
+    private static final long TEST_GUILD_ID = 1488762869880324200L;
+
+    private final ActionHandler actionHandler = ActionHandler.getInstance();
+    private final RollbackHandler rollbackHandler = RollbackHandler.getInstance();
+    private final GuildModerationActionsRepository actionRepository = GuildModerationActionsRepository.getInstance();
+
+    @BeforeAll
+    static void setup() {
+        database.initialize(appConfig);
+    }
+
+    @Test
+    @DisplayName("should apply timeout and rollback after 5 seconds")
+    @Order(1)
+    void shouldTimeoutThenRollback() {
+        Guild guild = getGuildOrSkip();
+        ensureMemberPresent(guild, TEST_ACCOUNT_2_ID);
+        clearTimeoutIfPresent(guild, TEST_ACCOUNT_2_ID);
+
+        // Apply timeout
+        long timeoutSeconds = 120;
+        ActionData timeoutAction = new ActionData(
+                UUID.randomUUID(),
+                Instant.now(),
+                new GuildID(TEST_GUILD_ID),
+                new UserID(TEST_ACCOUNT_2_ID),
+                new UserID(TEST_ACCOUNT_2_ID),
+                ActionType.TIMEOUT,
+                "Test timeout for rollback",
+                timeoutSeconds,
+                0,
+                List.of()
+        );
+
+        UUID testTimeoutActionId = timeoutAction.id();
+
+        // Save action to database first
+        boolean saved = actionRepository.addActionToDatabase(timeoutAction);
+        Assertions.assertTrue(saved, "Action should be saved to database");
+
+        boolean applied = actionHandler.processAction(timeoutAction);
+        Assertions.assertTrue(applied, "TIMEOUT action should apply successfully");
+
+        // Verify timeout was applied
+        Member timedOutMember = guild.retrieveMemberById(TEST_ACCOUNT_2_ID).complete();
+        Assertions.assertNotNull(timedOutMember, "Member should be retrievable");
+        Assertions.assertTrue(timedOutMember.isTimedOut(), "Member should be timed out after action application");
+
+        // Wait 5 seconds
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assertions.fail("Thread sleep interrupted during test");
+        }
+
+        // Rollback timeout
+        boolean rolledBack = rollbackHandler.rollbackAction(testTimeoutActionId, "Test rollback after 5 seconds");
+        Assertions.assertTrue(rolledBack, "Timeout should be rolled back successfully");
+
+        // Verify timeout was removed
+        Member refreshedMember = guild.retrieveMemberById(TEST_ACCOUNT_2_ID).complete();
+        Assertions.assertNotNull(refreshedMember, "Member should still be retrievable after rollback");
+        Assertions.assertFalse(refreshedMember.isTimedOut(), "Member should no longer be timed out after rollback");
+    }
+
+    private Guild getGuildOrSkip() {
+        JDA jda = JDAManager.getInstance().getJDA();
+        Guild guild = jda.getGuildById(TEST_GUILD_ID);
+        Assumptions.assumeTrue(guild != null, "Test guild not found. Ensure bot is in the guild and ID is correct.");
+        return guild;
+    }
+
+    private Member ensureMemberPresent(Guild guild, long userId) {
+        Member member = guild.retrieveMemberById(userId).complete();
+        Assumptions.assumeTrue(member != null, "Member " + userId + " not found in test guild.");
+        return member;
+    }
+
+    private void clearTimeoutIfPresent(Guild guild, long userId) {
+        try {
+            Member member = guild.retrieveMemberById(userId).complete();
+            if (member != null && member.isTimedOut()) {
+                member.removeTimeout().reason("Clearing timeout before integration test").complete();
+            }
+        } catch (Exception ignored) {
+            // Best-effort cleanup: do not fail tests from teardown noise.
+        }
+    }
+}

--- a/src/test/java/net/honeyberries/database/TestAppealRepo.java
+++ b/src/test/java/net/honeyberries/database/TestAppealRepo.java
@@ -73,12 +73,12 @@ public class TestAppealRepo {
         UUID appealId = repository.createAppeal(TEST_GUILD_ID, TEST_USER_ID, ACTION_ID, "Unfair warning");
         assertNotNull(appealId);
 
-        var appeals = repository.getOpenAppeals(TEST_GUILD_ID);
+        var appeals = repository.getOpenAppealsForGuild(TEST_GUILD_ID);
         assertEquals(1, appeals.size());
         
         boolean closed = repository.closeAppeal(TEST_GUILD_ID, appealId, "Resolved as valid");
         assertTrue(closed);
         
-        assertTrue(repository.getOpenAppeals(TEST_GUILD_ID).isEmpty());
+        assertTrue(repository.getOpenAppealsForGuild(TEST_GUILD_ID).isEmpty());
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the appeals system, focusing on enhanced administrator capabilities and clearer separation of embed types for different audiences. The most important changes include the addition of a new `/appeal user` command for administrators to view all open appeals for a specific user, refactoring of repository methods for clarity and flexibility, and improved notification handling for both moderators and appellants.

### New Features

* Added a new `/appeal user` subcommand that allows administrators to view all open appeals for a specific user in a guild. This includes backend support in `AppealRepository` and frontend handling in `AppealCommands`. [[1]](diffhunk://#diff-d927c57d79aca656011ce7e0ddfdb91dd40315380b5ebecc9b2dcdae384c278bR69-R74) [[2]](diffhunk://#diff-d927c57d79aca656011ce7e0ddfdb91dd40315380b5ebecc9b2dcdae384c278bR116-R126) [[3]](diffhunk://#diff-d927c57d79aca656011ce7e0ddfdb91dd40315380b5ebecc9b2dcdae384c278bR352-R392) [[4]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9R253-R304)

### Refactoring and Improvements

* Renamed `getOpenAppeals` to `getOpenAppealsForGuild` in `AppealRepository` for clarity, and updated all usages accordingly. [[1]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9L138-R137) [[2]](diffhunk://#diff-d927c57d79aca656011ce7e0ddfdb91dd40315380b5ebecc9b2dcdae384c278bL224-R237) [[3]](diffhunk://#diff-d927c57d79aca656011ce7e0ddfdb91dd40315380b5ebecc9b2dcdae384c278bL276-R289) [[4]](diffhunk://#diff-2efe804188e0d291889c549c03df94cd481953e1455e251d884b5463be88628bL144-R157)
* Added a new method `getOpenAppealsForUserInGuild` to `AppealRepository` to support fetching open appeals for a specific user in a guild.
* Updated SQL queries in `getOpenAppealActionIds` and `getAllOpenAppealActionIds` to remove unnecessary `action_id IS NOT NULL` checks and ensure distinct results. [[1]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9L225-R227) [[2]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9L262-R314)

### UI and Notification Enhancements

* Split appeal embed construction into two methods: `buildAppealEmbedForAdmins` (for moderator/admin notifications with action buttons) and `buildAppealEmbedForAppellant` (for notifying the appellant without action buttons). Updated usages in code to use the appropriate embed type. [[1]](diffhunk://#diff-4d9a5397526cedc7af89617d23adeac81f93ccf58e628363857e6867124b3246L39-R39) [[2]](diffhunk://#diff-4d9a5397526cedc7af89617d23adeac81f93ccf58e628363857e6867124b3246R87-R139) [[3]](diffhunk://#diff-d927c57d79aca656011ce7e0ddfdb91dd40315380b5ebecc9b2dcdae384c278bL240-R253) [[4]](diffhunk://#diff-d927c57d79aca656011ce7e0ddfdb91dd40315380b5ebecc9b2dcdae384c278bL289-R302) [[5]](diffhunk://#diff-2efe804188e0d291889c549c03df94cd481953e1455e251d884b5463be88628bL144-R157)
* Modified the appeal submission flow to notify both moderators and the appellant upon a new appeal submission.

### Minor Cleanups

* Removed unused imports and made minor code style improvements. [[1]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9L18) [[2]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9R174-R175) [[3]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9R212) [[4]](diffhunk://#diff-635d561d974285785e190c1da9a73f5cd921d0e2ec85a48cc008dadfe2bb87d9L283-R339) [[5]](diffhunk://#diff-2efe804188e0d291889c549c03df94cd481953e1455e251d884b5463be88628bL3-R20)

These changes collectively improve the flexibility, clarity, and user experience of the appeals system for both administrators and users.