### PR TITLE
chore: bump dependencies and Gradle wrapper

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,10 +7,10 @@ org-liquibase-gradle = { id = "org.liquibase.gradle", version = "3.1.0" }
 
 [libraries]
 
-openai-java = "com.openai:openai-java:4.33.0"
+openai-java = "com.openai:openai-java:4.34.0"
 
 gson = "com.google.code.gson:gson:2.14.0"
-jackson-databind = "tools.jackson.core:jackson-databind:3.1.2"
+jackson-databind = "tools.jackson.core:jackson-databind:3.1.3"
 
 jda = "net.dv8tion:JDA:6.4.1"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- **openai-java** `4.33.0` → `4.34.0` (patch)
- **jackson-databind** `3.1.2` → `3.1.3` (patch)
- **Gradle wrapper** `9.4.1` → `9.5.0`

## Security Review

All dependencies were audited for known CVEs. No security-critical updates were required — the project was already on patched versions:

| Dependency | Version | CVE(s) | Status |
|---|---|---|---|
| `postgresql` (pgjdbc) | 42.7.11 | CVE-2026-42198 (SCRAM DoS) | ✅ Already patched — 42.7.11 is the fix release |
| `logback-classic` | 1.5.32 | CVE-2025-11226 (ACE, fixed in 1.5.19) | ✅ Already patched |
| `logback-classic` | 1.5.32 | CVE-2026-1225 (ACE, fixed in 1.5.25) | ✅ Already patched |
| `JDA` | 6.4.1 | — | ✅ Latest stable |

## Skipped pre-release hints from `refreshVersions`

- `slf4j-api` 2.1.0-alpha0/alpha1 — not stable, skipped
- `junit-platform-launcher` 6.1.0-M1/RC1 — not stable, skipped

## How this was generated

```
./gradlew refreshVersions
```

https://claude.ai/code/session_01BixfFuoL82UaMu73Swrw88

---
_Generated by [Claude Code](https://claude.ai/code/session_01BixfFuoL82UaMu73Swrw88)_