### PR TITLE
chore(deps): bump openai-java 4.34→4.35 and jline 4.0.15→4.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ org-liquibase-gradle = { id = "org.liquibase.gradle", version = "3.1.0" }
 
 [libraries]
 
-openai-java = "com.openai:openai-java:4.34.0"
+openai-java = "com.openai:openai-java:4.35.0"
 
 gson = "com.google.code.gson:gson:2.14.0"
 jackson-databind = "tools.jackson.core:jackson-databind:3.1.3"
@@ -38,7 +38,6 @@ liquibase-core = "org.liquibase:liquibase-core:5.0.2"
 
 picocli = "info.picocli:picocli:4.7.7"
 
-jline = "org.jline:jline:4.0.15"
-##                   ⬆ :4.0.15"
+jline = "org.jline:jline:4.1.0"
 
 apache-commons-lang3 = "org.apache.commons:commons-lang3:3.20.0"


### PR DESCRIPTION
## Summary

- Bumps `com.openai:openai-java` from 4.34.0 → **4.35.0** (minor)
- Bumps `org.jline:jline` from 4.0.15 → **4.1.0** (minor)
- All other dependencies audited and confirmed current; pre-release candidates (`slf4j-api 2.1.0-alpha`, `junit-platform-launcher 6.1.0-RC1`) intentionally skipped

## Dependency Audit Results

| Dependency | Current | Latest Stable | Update Type | Security |
|---|---|---|---|---|
| `com.openai:openai-java` | 4.34.0 | **4.35.0** | minor | ✅ clean |
| `org.jline:jline` | 4.0.15 | **4.1.0** | minor | ✅ clean |
| `com.google.code.gson:gson` | 2.14.0 | 2.14.0 | — | ✅ clean |
| `tools.jackson.core:jackson-databind` | 3.1.3 | 3.1.3 | — | ✅ clean |
| `net.dv8tion:JDA` | 6.4.1 | 6.4.1 | — | ✅ clean |
| `org.yaml:snakeyaml` | 2.6 | 2.6 | — | ✅ clean (2.x rewrote CVE-prone code) |
| `org.slf4j:slf4j-api` | 2.0.17 | 2.0.17 | — | ✅ clean |
| `ch.qos.logback:logback-classic` | 1.5.32 | 1.5.32 | — | ✅ clean (CVE-2025-11226 fixed in 1.5.19) |
| `org.postgresql:postgresql` | 42.7.11 | 42.7.11 | — | ✅ clean (this version IS the CVE-2026-42198 fix) |
| `com.zaxxer:HikariCP` | 7.0.2 | 7.0.2 | — | ✅ clean |
| `org.liquibase:liquibase-core` | 5.0.2 | 5.0.2 | — | ✅ clean (CVE-2025-59250 only affects MSSQL, not PostgreSQL) |
| `info.picocli:picocli` | 4.7.7 | 4.7.7 | — | ✅ clean |
| `org.apache.commons:commons-lang3` | 3.20.0 | 3.20.0 | — | ✅ clean |

## Test plan

- [x] `./gradlew refreshVersions` — confirmed available updates
- [x] `./gradlew runTest` — compiled successfully with Java 25; runtime exits only due to missing `POSTGRES_DB_PASSWORD` env var (expected in CI)
- [x] No breaking changes expected for these minor bumps

https://claude.ai/code/session_01FjgxeR3LxDE32v3w6qvFDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjgxeR3LxDE32v3w6qvFDA)_