### PR TITLE
chore: update jackson-databind to 3.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ org-liquibase-gradle = { id = "org.liquibase.gradle", version = "3.1.0" }
 openai-java = "com.openai:openai-java:4.39.1"
 
 gson = "com.google.code.gson:gson:2.14.0"
-jackson-databind = "tools.jackson.core:jackson-databind:3.1.4"
+jackson-databind = "tools.jackson.core:jackson-databind:3.2.0"
 
 jda = "net.dv8tion:JDA:6.4.2"
 

--- a/versions.properties
+++ b/versions.properties
@@ -9,5 +9,4 @@
 
 version.junit=6.1.0
 
-
 plugin.com.gradleup.shadow=9.4.2


### PR DESCRIPTION
## Summary

- Bumps `tools.jackson.core:jackson-databind` from **3.1.4 → 3.2.0** (minor) — the only remaining outdated dependency after the latest dev round of updates
- Cleans up a duplicate blank line in `versions.properties`

## Dependency audit (all libs as of 2026-06-13)

| Library | Before | After | Type | Notes |
|---|---|---|---|---|
| `openai-java` | 4.36.0 | 4.39.1 ✅ | minor | Already on dev |
| `jackson-databind` | 3.1.3 | **3.2.0** | minor | **This PR** |
| `jda` | 6.4.1 | 6.4.2 ✅ | patch | Already on dev |
| `logback-classic` | 1.5.32 | 1.5.34 ✅ | patch | Already on dev |
| `junit-platform-launcher` | 6.0.3 | 6.1.0 ✅ | minor | Already on dev |
| `jline` | 4.1.0 | 4.1.3 ✅ | patch | Already on dev |
| `com.gradleup.shadow` | 9.4.0 | 9.4.2 ✅ | patch | Already on dev |
| `slf4j-api` | 2.0.18 | — | — | Skipped: only alpha updates (2.1.0-alpha*) |
| `gson`, `snakeyaml`, `postgresql`, `HikariCP`, `liquibase-core`, `picocli`, `dotenv-*`, `commons-lang3` | — | — | — | Already at latest stable |

## Security advisories

No known CVEs in the updated version ranges. `jackson-databind` 3.x (tools.jackson.core) is the rewritten Jackson 3 generation and does not carry the historical deserialization CVEs from 2.x.

## Test plan

- [x] `./gradlew compileJava` — compiles clean with Java 25
- [x] `./gradlew runTest` — starts up, all classes load; exits on missing `POSTGRES_DB_PASSWORD` env var (expected in CI)

https://claude.ai/code/session_017XLue59UL5s2Nk699YR2xP

---
_Generated by [Claude Code](https://claude.ai/code/session_017XLue59UL5s2Nk699YR2xP)_