### PR TITLE
Dependency maintenance: security patches + version updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
       
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Java 25
         uses: actions/setup-java@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       POSTGRES_DB_PASSWORD: ${{ secrets.POSTGRES_DB_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Java 25
         uses: actions/setup-java@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       POSTGRES_DB_PASSWORD: modcord_ci
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Java 25
         uses: actions/setup-java@v5
@@ -64,7 +64,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Java 25
         uses: actions/setup-java@v5

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,33 +2,33 @@
 
 [plugins]
 
-com-gradleup-shadow = { id = "com.gradleup.shadow", version = "9.4.2" }
+com-gradleup-shadow = { id = "com.gradleup.shadow", version = "9.5.1" }
 org-liquibase-gradle = { id = "org.liquibase.gradle", version = "3.1.0" }
 
 [libraries]
 
-openai-java = "com.openai:openai-java:4.39.1"
+openai-java = "com.openai:openai-java:4.42.0"
 
 gson = "com.google.code.gson:gson:2.14.0"
-jackson-databind = "tools.jackson.core:jackson-databind:3.2.0"
+jackson-databind = "tools.jackson.core:jackson-databind:3.2.1"
 
-jda = "net.dv8tion:JDA:6.4.2"
+jda = "net.dv8tion:JDA:6.5.0"
 
 snakeyaml = "org.yaml:snakeyaml:2.6"
 
 slf4j-api = "org.slf4j:slf4j-api:2.0.18"
 
-logback-classic = "ch.qos.logback:logback-classic:1.5.34"
+logback-classic = "ch.qos.logback:logback-classic:1.5.38"
 
 dotenv-java = "io.github.cdimascio:dotenv-java:3.2.0"
 
 dotenv-kotlin = "io.github.cdimascio:dotenv-kotlin:6.5.1"
 
-junit-platform-launcher = "org.junit.platform:junit-platform-launcher:6.1.0"
+junit-platform-launcher = "org.junit.platform:junit-platform-launcher:6.1.1"
 
-postgresql = "org.postgresql:postgresql:42.7.11"
+postgresql = "org.postgresql:postgresql:42.7.13"
 
-hikari-cp = "com.zaxxer:HikariCP:7.0.2"
+hikari-cp = "com.zaxxer:HikariCP:7.1.0"
 
 liquibase-core = "org.liquibase:liquibase-core:5.0.3"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/versions.properties
+++ b/versions.properties
@@ -7,6 +7,6 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
-version.junit=6.1.0
+version.junit=6.1.1
 
-plugin.com.gradleup.shadow=9.4.2
+plugin.com.gradleup.shadow=9.5.1


### PR DESCRIPTION
## Summary

Full dependency maintenance sweep: ran `refreshVersions`, cross-checked every suggested update against changelogs/CVE databases, and applied everything confirmed safe. Two of the updates fix real, disclosed CVEs.

### Security fixes
- **`org.postgresql:postgresql` 42.7.11 → 42.7.13** — fixes **CVE-2026-54291** (GHSA-j92g-9f8w-j867): a silent channel-binding downgrade in SCRAM auth affecting 42.7.4–42.7.11 when `channelBinding=require` is set. Modcord doesn't currently set `channelBinding=require` (default `prefer` is unaffected), so exposure was low, but the driver was still unpatched.
- **`ch.qos.logback:logback-classic` 1.5.34 → 1.5.38** — fixes **CVE-2026-13006**: arbitrary code execution via the Janino-evaluated `condition` attribute of `<if>` config elements, if an attacker can influence the logback config or environment variables. Fully fixed as of 1.5.37; 1.5.38 is the latest patch on top.

### Other dependency updates (verified no breaking changes)
| Dependency | Old | New |
|---|---|---|
| `com.openai:openai-java` | 4.39.1 | 4.42.0 |
| `net.dv8tion:JDA` | 6.4.2 | 6.5.0 |
| `com.zaxxer:HikariCP` | 7.0.2 | 7.1.0 (fixes virtual-thread yield-spin in `ConcurrentBag`) |
| `tools.jackson.core:jackson-databind` | 3.2.0 | 3.2.1 |
| `org.junit.platform:junit-platform-launcher` | 6.1.0 | 6.1.1 |
| `com.gradleup.shadow` (plugin) | 9.4.2 | 9.5.1 |
| Gradle wrapper | 9.5.1 | 9.6.1 |

### GitHub Actions
- `actions/checkout` bumped v6 → v7 across `build.yml`, `test.yml`, `deploy.yml`, `release.yml`. v7's main behavior change is stricter default handling of `pull_request_target`/`workflow_run` fork-PR checkouts — none of these workflows use those triggers, so there's no impact.
- `actions/setup-java` (`@v5`), `actions/upload-artifact` (`@v7`), `tailscale/github-action` (`@v4`), `appleboy/scp-action` (`@v1`), `appleboy/ssh-action` (`@v1`), and `ncipollo/release-action` (`@v1`) are already pinned to floating major tags that already resolve to their current latest release — no change needed.

### Left unchanged
- `slf4j-api` stays on `2.0.18` — the only newer version is `2.1.0-alpha1` (pre-release), skipped per policy.
- Java toolchain is already on **25**, which remains the current LTS (next LTS, Java 29, isn't due until Sept 2027). Consistent across `build.gradle.kts` and all four workflow files already — no change needed.
- `gson`, `snakeyaml`, `dotenv-java`/`dotenv-kotlin`, `liquibase-core`, `apache-commons-lang3`, `resilience4j-all`, `org.liquibase.gradle` plugin, and `testcontainers-*` were confirmed already at their latest stable Maven Central releases — no update available.

## Testing

The sandbox this PR was prepared in has restricted egress (can't fetch the Gradle 9.x binary distribution or auto-provision a JDK via toolchain resolvers, since Gradle's distribution hosting redirects through `github.com` release assets, which aren't reachable in that environment). Given that constraint, verification was done as follows:

- Installed JDK 25 directly (Oracle build) and used a pre-existing Gradle 8.14.3 to configure the project and resolve all updated dependencies from Maven Central — confirms no dependency conflicts and that the version catalog is valid.
- Ran `compileJava` + `compileTestJava` + `test` (with the Shadow plugin temporarily, locally disabled only because Shadow 9.5.x requires Gradle ≥ 9.2, which the sandbox's fallback Gradle 8.14.3 doesn't satisfy — this was reverted before committing, so the plugin bump ships as intended) — **all passed** against the new dependency versions.
- Could not locally run `./gradlew assemble` (Shadow JAR build) or `./gradlew runTest` end-to-end due to the same Gradle-version/network constraint; the Gradle wrapper bump to 9.6.1 and the committed Shadow plugin version are what CI will actually exercise, with full internet access.

## Test plan
- [ ] CI `Compile Modcord` workflow passes (`./gradlew assemble`, exercises the Shadow plugin bump end-to-end)
- [ ] CI `Run Tests` workflow passes (`./gradlew runTest`, `./gradlew cleanTest test integrationTest`)
- [x] Local `compileJava`, `compileTestJava`, and unit `test` verified against all updated dependency versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxC7kEZTyXQAxjSbsnj8v2)_