### PR TITLE
Add appeals_enabled guild preference (feature flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,11 @@ Configure how the bot behaves in your server:
 - `ai` — Enable or disable AI moderation for the guild
 - `rules_channel` — Set the channel where server rules are posted
 - `audit_channel` — Set the channel for moderation action logs
-- `settings` — View current preferences and configuration
+- `action` — Enable or disable a specific moderation action (warn, timeout, delete, kick, ban)
+- `appeals` — Allow or block users from submitting moderation appeals (default: allow)
+- `remove_on_delete` — Whether deleted messages are removed from the moderation queue (default: keep, to catch ghost pings)
+- `settings` — View and manage current preferences with an interactive interface
+- `reset` — Reset all preferences to their default values
 
 #### `/mod` — Manual Moderation Actions
 Take direct moderation action against users:

--- a/src/main/java/net/honeyberries/database/repository/GuildPreferencesRepository.java
+++ b/src/main/java/net/honeyberries/database/repository/GuildPreferencesRepository.java
@@ -70,8 +70,8 @@ public class GuildPreferencesRepository {
                                 guild_id, ai_enabled, rules_channel_id,
                                 auto_warn_enabled, auto_delete_enabled, auto_timeout_enabled,
                                 auto_kick_enabled, auto_ban_enabled, audit_log_channel_id,
-                                remove_on_delete_enabled
-                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                remove_on_delete_enabled, appeals_enabled
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                             ON CONFLICT (guild_id) DO UPDATE SET
                                 ai_enabled             = EXCLUDED.ai_enabled,
                                 rules_channel_id       = EXCLUDED.rules_channel_id,
@@ -81,7 +81,8 @@ public class GuildPreferencesRepository {
                                 auto_kick_enabled      = EXCLUDED.auto_kick_enabled,
                                 auto_ban_enabled       = EXCLUDED.auto_ban_enabled,
                                 audit_log_channel_id   = EXCLUDED.audit_log_channel_id,
-                                remove_on_delete_enabled = EXCLUDED.remove_on_delete_enabled
+                                remove_on_delete_enabled = EXCLUDED.remove_on_delete_enabled,
+                                appeals_enabled        = EXCLUDED.appeals_enabled
                         """;
 
                 try (PreparedStatement ps = conn.prepareStatement(upsertSql)) {
@@ -109,6 +110,7 @@ public class GuildPreferencesRepository {
                     }
 
                     ps.setBoolean(10, guildPreferences.removeOnDeleteEnabled());
+                    ps.setBoolean(11, guildPreferences.appealsEnabled());
 
                     ps.executeUpdate();
                 }
@@ -136,7 +138,7 @@ public class GuildPreferencesRepository {
                     SELECT guild_id, ai_enabled, rules_channel_id,
                            auto_warn_enabled, auto_delete_enabled, auto_timeout_enabled,
                            auto_kick_enabled, auto_ban_enabled, audit_log_channel_id,
-                           remove_on_delete_enabled
+                           remove_on_delete_enabled, appeals_enabled
                     FROM guild_preferences
                     WHERE guild_id = ?
                 """;
@@ -213,7 +215,8 @@ public class GuildPreferencesRepository {
                 rs.getBoolean("auto_kick_enabled"),
                 rs.getBoolean("auto_ban_enabled"),
                 rs.getBoolean("remove_on_delete_enabled"),
-                auditLogChannelId
+                auditLogChannelId,
+                rs.getBoolean("appeals_enabled")
         );
     }
 

--- a/src/main/java/net/honeyberries/datatypes/preferences/GuildPreferences.java
+++ b/src/main/java/net/honeyberries/datatypes/preferences/GuildPreferences.java
@@ -23,7 +23,8 @@ public record GuildPreferences(
         boolean             autoKickEnabled,
         boolean             autoBanEnabled,
         boolean             removeOnDeleteEnabled,
-        @Nullable ChannelID auditLogChannelId
+        @Nullable ChannelID auditLogChannelId,
+        boolean             appealsEnabled
 ) {
     // ── Compact canonical constructor ────────────────────────────────────────
 
@@ -64,7 +65,8 @@ public record GuildPreferences(
                 .autoKickEnabled(autoKickEnabled)
                 .autoBanEnabled(autoBanEnabled)
                 .removeOnDeleteEnabled(removeOnDeleteEnabled)
-                .auditLogChannelId(auditLogChannelId);
+                .auditLogChannelId(auditLogChannelId)
+                .appealsEnabled(appealsEnabled);
     }
 
     // ── Convenience withers (one-liners via toBuilder) ────────────────────────
@@ -80,6 +82,7 @@ public record GuildPreferences(
     public @NotNull GuildPreferences withRemoveOnDeleteEnabled(boolean v) { return toBuilder().removeOnDeleteEnabled(v).build(); }
     public @NotNull GuildPreferences withAuditLogChannelId(@Nullable ChannelID v) { return toBuilder().auditLogChannelId(v).build(); }
     public @NotNull GuildPreferences withAuditLogChannelId(long v)         { return withAuditLogChannelId(new ChannelID(v)); }
+    public @NotNull GuildPreferences withAppealsEnabled(boolean v)         { return toBuilder().appealsEnabled(v).build(); }
 
     // ── Builder ───────────────────────────────────────────────────────────────
 
@@ -97,6 +100,7 @@ public record GuildPreferences(
         private boolean             autoBanEnabled     = true;
         private boolean             removeOnDeleteEnabled = false;
         private @Nullable ChannelID auditLogChannelId  = null;
+        private boolean             appealsEnabled     = true;
 
         public Builder(@NotNull GuildID guildId) {
             this.guildId = Objects.requireNonNull(guildId, "guildId must not be null");
@@ -113,6 +117,7 @@ public record GuildPreferences(
         public @NotNull Builder removeOnDeleteEnabled(boolean v)            { removeOnDeleteEnabled = v; return this; }
         public @NotNull Builder auditLogChannelId(@Nullable ChannelID v)    { auditLogChannelId = v;  return this; }
         public @NotNull Builder auditLogChannelId(long v)                   { return auditLogChannelId(new ChannelID(v)); }
+        public @NotNull Builder appealsEnabled(boolean v)                   { appealsEnabled = v;     return this; }
 
         public @NotNull GuildPreferences build() {
             return new GuildPreferences(
@@ -125,7 +130,8 @@ public record GuildPreferences(
                     autoKickEnabled,
                     autoBanEnabled,
                     removeOnDeleteEnabled,
-                    auditLogChannelId
+                    auditLogChannelId,
+                    appealsEnabled
             );
         }
     }

--- a/src/main/java/net/honeyberries/discord/slashCommands/PreferencesCommands.java
+++ b/src/main/java/net/honeyberries/discord/slashCommands/PreferencesCommands.java
@@ -129,11 +129,19 @@ public class PreferencesCommands extends ListenerAdapter {
                         "true = remove on delete (old behavior); false = catch ghost pings (leave empty to view)", false)
         );
 
+        SubcommandData appealsSub = new SubcommandData(
+                "appeals",
+                "Enable or disable whether users can submit moderation appeals (or view current setting)"
+        ).addOptions(
+                new OptionData(OptionType.BOOLEAN, "enabled",
+                        "Allow or block moderation appeals (leave empty to view current)", false)
+        );
+
         SlashCommandData preferencesCommand = Commands.slash(
                 "preferences",
                 "Manage guild preferences and settings"
         ).addSubcommands(
-                aiSub, rulesChannelSub, auditChannelSub, settingsSub, resetSub, actionSub, removeOnDeleteSub);
+                aiSub, rulesChannelSub, auditChannelSub, settingsSub, resetSub, actionSub, removeOnDeleteSub, appealsSub);
 
         commands.addCommands(preferencesCommand);
         logger.info("Registered /preferences command with subcommands");
@@ -171,6 +179,7 @@ public class PreferencesCommands extends ListenerAdapter {
                 case "reset"             -> helper.handleReset(event, guild);
                 case "action"            -> helper.handleAction(event, guild);
                 case "remove_on_delete"  -> helper.handleRemoveOnDelete(event, guild);
+                case "appeals"           -> helper.handleAppeals(event, guild);
                 default                  -> event.reply("Unknown subcommand.").setEphemeral(true).queue();
             }
         } catch (Exception e) {

--- a/src/main/java/net/honeyberries/ui/PreferencesEmbedUI.java
+++ b/src/main/java/net/honeyberries/ui/PreferencesEmbedUI.java
@@ -79,6 +79,7 @@ public class PreferencesEmbedUI {
             rows.add(buildActionToggleRow(prefs));
         } else if (category.equals("flags")) {
             rows.add(buildRemoveOnDeleteToggleRow(prefs));
+            rows.add(buildAppealsToggleRow(prefs));
         }
 
         rows.add(buildNavigationRow(category));
@@ -116,6 +117,24 @@ public class PreferencesEmbedUI {
                 Button.primary("pref_remove_on_delete_toggle",
                                 "Catch Ghost Pings: " + (removeOnDelete ? "OFF" : "ON"))
                         .withStyle(removeOnDelete ? ButtonStyle.DANGER : ButtonStyle.SUCCESS)
+        );
+    }
+
+    /**
+     * Builds the "appeals" toggle button row.
+     *
+     * <p>Styled like other feature toggles: green (SUCCESS) when appeals are enabled
+     * (the default), red (DANGER) when disabled.</p>
+     *
+     * @param prefs the current guild preferences
+     * @return an action row containing the appeals toggle button
+     */
+    private static ActionRow buildAppealsToggleRow(@NotNull GuildPreferences prefs) {
+        boolean appealsEnabled = prefs.appealsEnabled();
+        return ActionRow.of(
+                Button.primary("pref_appeals_toggle",
+                                "Appeals: " + (appealsEnabled ? "ON" : "OFF"))
+                        .withStyle(appealsEnabled ? ButtonStyle.SUCCESS : ButtonStyle.DANGER)
         );
     }
 

--- a/src/main/java/net/honeyberries/util/AppealCommandHelper.java
+++ b/src/main/java/net/honeyberries/util/AppealCommandHelper.java
@@ -15,6 +15,7 @@ import net.honeyberries.datatypes.action.ActionType;
 import net.honeyberries.datatypes.action.AppealData;
 import net.honeyberries.datatypes.discord.GuildID;
 import net.honeyberries.datatypes.discord.UserID;
+import net.honeyberries.preferences.PreferencesManager;
 import net.honeyberries.services.NotificationService;
 import net.honeyberries.ui.AppealEmbedUI;
 import org.jetbrains.annotations.NotNull;
@@ -55,6 +56,15 @@ public class AppealCommandHelper {
         } else {
             // Guild context: fetch actions for this specific guild
             GuildID guildId = new GuildID(event.getGuild().getIdLong());
+
+            // Block outright if this guild has disabled appeals
+            if (!appealsEnabledForGuild(guildId)) {
+                event.reply("Appeals are disabled for this server.")
+                        .setEphemeral(true)
+                        .queue();
+                return;
+            }
+
             allActions.addAll(actionRepository.getActionsByUser(guildId, userId));
 
             // Collect already-appealed action IDs for this guild
@@ -62,10 +72,17 @@ public class AppealCommandHelper {
             alreadyAppealedIds.addAll(appealedIds);
         }
 
-        // Filter: keep only BAN, KICK, WARN, TIMEOUT; remove already-appealed actions
+        // Cache per-guild appeals-enabled lookups so the DM filter below hits the DB once per guild
+        Map<GuildID, Boolean> appealsEnabledCache = new HashMap<>();
+
+        // Filter: keep only BAN, KICK, WARN, TIMEOUT; remove already-appealed actions;
+        // and drop actions whose originating guild has disabled appeals (matters for the DM flow,
+        // where a single submission can span multiple guilds).
         List<ActionData> eligibleActions = allActions.stream()
                 .filter(action -> isAppealableActionType(action.action()))
                 .filter(action -> !alreadyAppealedIds.contains(action.id()))
+                .filter(action -> appealsEnabledCache
+                        .computeIfAbsent(action.guildId(), this::appealsEnabledForGuild))
                 .toList();
 
         if (eligibleActions.isEmpty()) {
@@ -124,6 +141,13 @@ public class AppealCommandHelper {
         ActionData action = actionRepository.getActionById(actionId);
         if (action == null) {
             event.reply("The action you are appealing no longer exists.").setEphemeral(true).queue();
+            return;
+        }
+
+        // Re-check the guild's appeals flag: guards against a stale select menu submitted
+        // after an admin disabled appeals between the menu being shown and this submission.
+        if (!appealsEnabledForGuild(action.guildId())) {
+            event.reply("Appeals are disabled for this server.").setEphemeral(true).queue();
             return;
         }
 
@@ -308,5 +332,16 @@ public class AppealCommandHelper {
         return actionType == ActionType.BAN
                 || actionType == ActionType.KICK
                 || actionType == ActionType.TIMEOUT;
+    }
+
+    /**
+     * Checks whether the given guild currently allows moderation appeals.
+     *
+     * @param guildId the guild to check, must not be {@code null}
+     * @return {@code true} if appeals are enabled (the default) for the guild
+     */
+    private boolean appealsEnabledForGuild(@NotNull GuildID guildId) {
+        Objects.requireNonNull(guildId, "guildId must not be null");
+        return PreferencesManager.getInstance().getOrDefaultPreferences(guildId).appealsEnabled();
     }
 }

--- a/src/main/java/net/honeyberries/util/PreferenceCommandHelper.java
+++ b/src/main/java/net/honeyberries/util/PreferenceCommandHelper.java
@@ -146,6 +146,36 @@ public class PreferenceCommandHelper {
     }
 
     /**
+     * Handles the {@code /preferences appeals} subcommand.
+     *
+     * <p>If {@code enabled} is omitted, reports the current setting. Otherwise,
+     * enables or disables whether users can submit moderation appeals for the guild.</p>
+     *
+     * @param event the slash command interaction event
+     * @param guild the guild where the command was invoked (validated)
+     * @throws NullPointerException if event or guild is null
+     */
+    public void handleAppeals(@NotNull SlashCommandInteractionEvent event, @NotNull Guild guild) {
+        Objects.requireNonNull(event, "event must not be null");
+        Objects.requireNonNull(guild, "guild must not be null");
+        try {
+            GuildID guildId = GuildID.fromGuild(guild);
+            Boolean enabled = event.getOption("enabled", OptionMapping::getAsBoolean);
+
+            if (enabled == null) {
+                reportAppealsStatus(event, guildId);
+                return;
+            }
+
+            updateAppealsStatus(event, guildId, enabled);
+        } catch (Exception e) {
+            logger.error("Error handling appeals subcommand", e);
+            event.reply(PreferencesCommands.PreferencesMessages.UPDATE_FAILED)
+                    .setEphemeral(true).queue();
+        }
+    }
+
+    /**
      * Handles the {@code /preferences set_rules_channel} subcommand.
      *
      * <p>If {@code channel} is omitted, reports the currently configured channel.
@@ -339,6 +369,8 @@ public class PreferenceCommandHelper {
             handleActionToggleButton(event, guildId, componentId);
         } else if (componentId.equals("pref_remove_on_delete_toggle")) {
             handleRemoveOnDeleteToggleButton(event, guildId);
+        } else if (componentId.equals("pref_appeals_toggle")) {
+            handleAppealsToggleButton(event, guildId);
         }
     }
 
@@ -533,6 +565,20 @@ public class PreferenceCommandHelper {
     }
 
     /**
+     * Handles the appeals toggle button click.
+     *
+     * @param event the button interaction event
+     * @param guildId the guild ID
+     */
+    private void handleAppealsToggleButton(@NotNull ButtonInteractionEvent event, @NotNull GuildID guildId) {
+        GuildPreferences prefs = PreferencesManager.getInstance().getOrDefaultPreferences(guildId);
+        prefs = prefs.withAppealsEnabled(!prefs.appealsEnabled());
+        PreferencesManager.getInstance().updatePreferences(prefs);
+        event.editMessageEmbeds(PreferencesEmbedUI.buildSettingsEmbed("flags"))
+                .setComponents(PreferencesEmbedUI.buildSettingsComponents(guildId, "flags")).queue();
+    }
+
+    /**
      * Handles channel selection in entity select menus.
      *
      * @param event the entity select interaction event
@@ -623,6 +669,42 @@ public class PreferenceCommandHelper {
             event.reply("Remove-on-delete has been **" + status + "** for this guild.")
                     .setEphemeral(true).queue();
             logger.debug("Guild {} remove-on-delete set to {}", guildId.value(), enabled);
+        } else {
+            event.reply(PreferencesCommands.PreferencesMessages.UPDATE_FAILED)
+                    .setEphemeral(true).queue();
+        }
+    }
+
+    /**
+     * Reports the current appeals status for a guild.
+     *
+     * @param event the slash command interaction event
+     * @param guildId the guild ID
+     */
+    private void reportAppealsStatus(@NotNull SlashCommandInteractionEvent event, @NotNull GuildID guildId) {
+        GuildPreferences prefs = PreferencesManager.getInstance().getOrDefaultPreferences(guildId);
+        String status = prefs.appealsEnabled() ? "**enabled**" : "**disabled**";
+        event.reply("Moderation appeals are currently " + status + " for this guild.")
+                .setEphemeral(true).queue();
+    }
+
+    /**
+     * Updates the appeals status for a guild.
+     *
+     * @param event the slash command interaction event
+     * @param guildId the guild ID
+     * @param enabled the desired enabled state
+     */
+    private void updateAppealsStatus(@NotNull SlashCommandInteractionEvent event, @NotNull GuildID guildId, boolean enabled) {
+        GuildPreferences prefs = PreferencesManager.getInstance()
+                .getOrDefaultPreferences(guildId)
+                .withAppealsEnabled(enabled);
+
+        if (PreferencesManager.getInstance().updatePreferences(prefs)) {
+            String status = enabled ? "enabled" : "disabled";
+            event.reply("Moderation appeals have been **" + status + "** for this guild.")
+                    .setEphemeral(true).queue();
+            logger.debug("Guild {} appeals set to {}", guildId.value(), enabled);
         } else {
             event.reply(PreferencesCommands.PreferencesMessages.UPDATE_FAILED)
                     .setEphemeral(true).queue();

--- a/src/main/resources/db/changelog/changelog-v21.sql
+++ b/src/main/resources/db/changelog/changelog-v21.sql
@@ -1,0 +1,5 @@
+-- liquibase formatted sql
+
+-- changeset modcord:21
+-- comment: Add appeals_enabled flag to control whether users can submit moderation appeals
+ALTER TABLE guild_preferences ADD COLUMN appeals_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -24,5 +24,6 @@
     <include file="db/changelog/changelog-v17.sql"/>
     <include file="db/changelog/changelog-v18.sql"/>
     <include file="db/changelog/changelog-v20.sql"/>
+    <include file="db/changelog/changelog-v21.sql"/>
 
 </databaseChangeLog>

--- a/src/test/java/net/honeyberries/database/TestGuildPreferencesRepo.java
+++ b/src/test/java/net/honeyberries/database/TestGuildPreferencesRepo.java
@@ -43,6 +43,30 @@ public class TestGuildPreferencesRepo extends PostgresTestSupport {
         assertEquals(TEST_CHANNEL_ID, retrieved.rulesChannelID());
         assertEquals(TEST_CHANNEL_ID, retrieved.auditLogChannelId());
         assertFalse(retrieved.autoWarnEnabled());
+        assertTrue(retrieved.appealsEnabled(), "Appeals should default to enabled");
+    }
+
+    @Test
+    @DisplayName("Should default appeals to enabled")
+    void shouldDefaultAppealsEnabled() {
+        GuildPreferences prefs = GuildPreferences.defaults(TEST_GUILD_ID);
+        assertTrue(prefs.appealsEnabled(), "Appeals should be enabled by default");
+
+        repository.addOrUpdateGuildPreferences(prefs);
+        GuildPreferences retrieved = repository.getGuildPreferences(TEST_GUILD_ID);
+        assertNotNull(retrieved);
+        assertTrue(retrieved.appealsEnabled(), "Appeals should persist as enabled by default");
+    }
+
+    @Test
+    @DisplayName("Should persist appeals disabled after toggle")
+    void shouldPersistAppealsDisabled() {
+        GuildPreferences prefs = GuildPreferences.defaults(TEST_GUILD_ID).withAppealsEnabled(false);
+        assertTrue(repository.addOrUpdateGuildPreferences(prefs), "Upsert should succeed");
+
+        GuildPreferences retrieved = repository.getGuildPreferences(TEST_GUILD_ID);
+        assertNotNull(retrieved);
+        assertFalse(retrieved.appealsEnabled(), "Appeals should be disabled after toggle");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a per-guild **appeals** feature flag that controls whether users can submit moderation appeals. It **defaults to enabled** (preserving current behavior) and is stored in the `guild_preferences` table alongside the other feature flags.

This mirrors the existing `remove_on_delete` flag end-to-end so it stays consistent with the established preferences pattern (data model → repository → migration → slash subcommand → settings GUI toggle → tests → docs), plus enforcement in the appeal flow.

## Changes

**Data model & persistence**
- `GuildPreferences`: new `appealsEnabled` record component (Builder default `true`), wither, and builder support.
- `GuildPreferencesRepository`: persist/read the new `appeals_enabled` column (upsert, `ON CONFLICT`, select, and `mapPreferences`).
- Liquibase `changelog-v21.sql` (registered in `db.changelog-master.xml`): `ALTER TABLE guild_preferences ADD COLUMN appeals_enabled BOOLEAN NOT NULL DEFAULT TRUE`.

**Admin controls**
- New `/preferences appeals [enabled]` subcommand — view current setting when the option is omitted, or enable/disable it.
- Settings GUI: an **Appeals** toggle button in the *Feature Flags* category (green = ON/default, red = OFF).

**Enforcement** (in `AppealCommandHelper`)
- `handleShowActionSelect`: in guild context, block outright when appeals are disabled; in DM context, filter out actions belonging to guilds that have disabled appeals (a DM submission can span multiple guilds), using a per-guild cache to avoid repeated lookups.
- `handleModalSubmit`: re-check the guild's flag before creating the appeal, guarding against a stale select menu submitted after an admin disables appeals.

**Tests**
- `TestGuildPreferencesRepo`: assert the default is enabled and that a disabled toggle persists.

**Docs**
- README: document the new `appeals` subcommand and backfill the previously-undocumented `action`, `reset`, and `remove_on_delete` subcommands.

## Testing

⚠️ I was **unable to run the build/tests in this environment**: the project pins Gradle 9.6.1 via the wrapper, and downloading it is blocked by the environment's egress policy (HTTP 403 from `services.gradle.org`); the only local Gradle is 8.14.3, which is incompatible with the project's plugins. The changes were verified by careful code review (record-component ordering matches both positional constructor sites; SQL column/placeholder/bind indices are aligned). **CI should run `./gradlew compileJava test` to validate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Qm7j2GCKH7MTHXSS1wZ98)_