### PR TITLE
Dependency maintenance: update openai-java, logback-classic, shadow plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ org-liquibase-gradle = { id = "org.liquibase.gradle", version = "3.1.0" }
 
 [libraries]
 
-openai-java = "com.openai:openai-java:4.45.0"
+openai-java = "com.openai:openai-java:4.49.0"
 
 gson = "com.google.code.gson:gson:2.14.0"
 jackson-databind = "tools.jackson.core:jackson-databind:3.2.1"
@@ -20,7 +20,7 @@ slf4j-api = "org.slf4j:slf4j-api:2.0.18"
 ##                           ⬆ :2.1.0-alpha0"
 ##                           ⬆ :2.1.0-alpha1"
 
-logback-classic = "ch.qos.logback:logback-classic:1.6.0"
+logback-classic = "ch.qos.logback:logback-classic:1.6.1"
 
 dotenv-java = "io.github.cdimascio:dotenv-java:3.2.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,12 @@
 
 [plugins]
 
-com-gradleup-shadow = { id = "com.gradleup.shadow", version = "9.6.0" }
+com-gradleup-shadow = { id = "com.gradleup.shadow", version = "9.6.1" }
 org-liquibase-gradle = { id = "org.liquibase.gradle", version = "3.1.0" }
 
 [libraries]
 
-openai-java = "com.openai:openai-java:4.43.0"
+openai-java = "com.openai:openai-java:4.45.0"
 
 gson = "com.google.code.gson:gson:2.14.0"
 jackson-databind = "tools.jackson.core:jackson-databind:3.2.1"
@@ -20,7 +20,7 @@ slf4j-api = "org.slf4j:slf4j-api:2.0.18"
 ##                           ⬆ :2.1.0-alpha0"
 ##                           ⬆ :2.1.0-alpha1"
 
-logback-classic = "ch.qos.logback:logback-classic:1.5.38"
+logback-classic = "ch.qos.logback:logback-classic:1.6.0"
 
 dotenv-java = "io.github.cdimascio:dotenv-java:3.2.0"
 

--- a/versions.properties
+++ b/versions.properties
@@ -9,4 +9,4 @@
 
 version.junit=6.1.2
 
-plugin.com.gradleup.shadow=9.6.0
+plugin.com.gradleup.shadow=9.6.1


### PR DESCRIPTION
## Summary

Routine dependency maintenance review of the Gradle build. Ran `./gradlew refreshVersions` and cross-checked every dependency, plugin, the Gradle wrapper, GitHub Actions versions, and the CI Postgres Docker image against Maven Central / upstream metadata.

This PR has been updated by a follow-up automated review: newer releases became available for `openai-java` and `logback-classic` in the time since the first commit was pushed, so those were bumped further.

### Dependency Information

| Dependency | Current → Latest | Type |
|---|---|---|
| `com.openai:openai-java` | 4.43.0 → 4.49.0 | minor |
| `ch.qos.logback:logback-classic` | 1.5.38 → 1.6.1 | minor |
| `com.gradleup.shadow` (plugin) | 9.6.0 → 9.6.1 | patch |

### Compatibility Analysis

- **openai-java 4.49.0**: Reviewed every release note from 4.44.0 through 4.49.0. All are additive features and bug fixes, except **4.46.0**, which removed the `openai-java-spring-boot-2-starter` module ("establish Java support policy and retire the Spring Boot 2 starter"). This project only depends on the plain `com.openai:openai-java` artifact (verified via repo-wide search — no Spring Boot usage anywhere), so this breaking change doesn't apply. No other breaking API changes.
- **logback-classic 1.6.1**: Bug-fix/behavior release on top of 1.6.0 (rolling-policy temp-file naming, compression-failure handling, console appender ANSI detection). No new breaking changes. 1.6.0's removal of deprecated internals was already reviewed and confirmed safe — the project only uses `ConsoleAppender`, `PatternLayoutEncoder`, `RollingFileAppender`, and `TimeBasedRollingPolicy` in `logback.xml`, with no direct Java code depending on logback internals.
- **shadow plugin 9.6.1**: Patch release, no compatibility concerns. Also synced `versions.properties`, which still listed the plugin at the pre-update version even though `libs.versions.toml` had already been bumped.

### Security Information

No known CVEs found affecting the current pinned versions. This is a routine maintenance pass, not a security-driven update.

### Not Changed (already up to date)

- **Gradle wrapper**: 9.6.1 is the current stable release (9.7.0 exists only as a milestone/RC — skipped per policy of avoiding non-stable releases).
- **Java toolchain**: Already Java 25 (latest LTS) across `build.gradle.kts`, `.github/workflows/*.yml`. No Docker images in this repo to update besides the CI-only Postgres service image.
- **JDA, postgresql, HikariCP, liquibase-core, resilience4j-all, testcontainers-*, gson, jackson-databind, snakeyaml, commons-lang3, dotenv-java/kotlin, junit-platform-launcher, org.liquibase.gradle plugin, de.fayard.refreshVersions plugin**: all confirmed at latest stable release via Maven Central `maven-metadata.xml` / `refreshVersions`.
- **`slf4j-api`**: latest stable is still 2.0.18 (current); 2.1.0 only exists as alpha — skipped per policy.
- **GitHub Actions** (`actions/checkout`, `actions/setup-java`, `actions/upload-artifact`, `tailscale/github-action`, `appleboy/scp-action`, `appleboy/ssh-action`, `ncipollo/release-action`): all workflows already pin the latest floating major-version tag, which GitHub automatically re-points to the newest release in that major line — no changes needed.
- **CI Postgres image** (`postgres:18-alpine` in `test.yml`): 18 is the latest major version on Docker Hub.

### Testing Results

- `./gradlew build` — **passes** (compile, unit tests, `shadowJar`, `assemble`).
- `./gradlew runTest` — reached the database-initialization stage of the bot with the updated dependencies (config loaded, AI config resolved, HikariCP pool creation attempted) before failing on `UnknownHostException` for the Azure-hosted Postgres instance referenced in `app_config.yml`. This is a sandbox network-access limitation (no route to the private DB host / no real secrets available), unrelated to this dependency change — consistent with the same limitation hit on the first commit of this PR. CI's `test.yml` spins up a real Postgres service container and has the real secrets configured, so it provides authoritative runtime verification.

### Version Changes

No project version bump — this is a dependency-only update per repository convention.